### PR TITLE
fix(PWA): cache all required files and assets

### DIFF
--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -7,9 +7,8 @@
       "files": [
         "/favicon.ico",
         "/index.html",
-        "/*.bundle.css",
-        "/*.bundle.js",
-        "/*.chunk.js"
+        "/*.css",
+        "/*.js"
       ]
     }
   }, {


### PR DESCRIPTION
The bug is due to the fact that not all the required assets are cached, such as polyfills and scripts files.